### PR TITLE
Fixed mismatch secfrac-microseconds (#314)

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,17 +44,18 @@ def test_bug_196():
     assert round_trip_bug_dict['x'] == bug_dict['x']
 
 def test_bug_314():
-    data = """12:34:56.1 1
-12:34:56.12 12
-12:34:56.123 123
-12:34:56.1234 1234
-12:34:56.12345 12345
-12:34:56.123456 123456
-12:34:56.1234567 123456"""
-    for line in data.splitlines():
-        input_, expected = tuple(line.split(" "))
-        decoded = toml.loads(f"a={input_}")['a']
-        assert decoded.microsecond == int(expected)
+    data = (
+        ("12:34:56.1", 100000),
+        ("12:34:56.12", 120000),
+        ("12:34:56.123", 123000),
+        ("12:34:56.1234", 123400),
+        ("12:34:56.12345", 123450),
+        ("12:34:56.123456", 123456),
+        ("12:34:56.1234567", 123456)
+    )
+    for input_time, expected_microsecond in data:
+        decoded = toml.loads(f"a={input_time}")['a']
+        assert decoded.microsecond == expected_microsecond
 
 def test_valid_tests():
     valid_dir = "toml-test/tests/valid/"

--- a/toml/decoder.py
+++ b/toml/decoder.py
@@ -878,8 +878,9 @@ class TomlDecoder(object):
             self.load_inline_object(v, inline_object)
             return (inline_object, "inline_object")
         elif TIME_RE.match(v):
-            h, m, s, _, ms = TIME_RE.match(v).groups()
-            time = datetime.time(int(h), int(m), int(s), int(ms) if ms else 0)
+            h, m, s, _, secfrac = TIME_RE.match(v).groups()
+            ms = int(int(secfrac) * (10 ** (6 - len(secfrac)))) if secfrac else 0
+            time = datetime.time(int(h), int(m), int(s), int(ms))
             return (time, "time")
         else:
             parsed_date = _load_date(v)


### PR DESCRIPTION
Time values with fractions of seconds were parsed wrongly, despite date
parsing was fine.